### PR TITLE
Add ability to test whether a connection has already been defined

### DIFF
--- a/EWS/Connect-EWSService.ps1
+++ b/EWS/Connect-EWSService.ps1
@@ -11,7 +11,9 @@ function Connect-EWSService {
 
         [Microsoft.Exchange.WebServices.Data.ExchangeVersion]
         $Version = [Microsoft.Exchange.WebServices.Data.ExchangeVersion]::Exchange2013_SP1,
-
+        
+        [switch]$AllowRedirect,
+        
         [Management.Automation.PSCredential]
         [Management.Automation.Credential()]
         $Credential = [Management.Automation.PSCredential]::Empty
@@ -30,7 +32,7 @@ function Connect-EWSService {
         $exchangeService.Url = $ServiceUrl
     } else {
         try {
-            $exchangeService.AutodiscoverUrl($Mailbox)
+            $exchangeService.AutodiscoverUrl($Mailbox,{[bool]$AllowRedirect})
         } catch {
             throw "Failed to identify Url for $Mailbox - $_"
         }

--- a/EWS/EWS.psd1
+++ b/EWS/EWS.psd1
@@ -12,7 +12,7 @@
 RootModule = 'EWS.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.1'
+ModuleVersion = '1.1.4'
 
 # ID used to uniquely identify this module
 GUID = 'd1acb385-ff90-400f-ac66-04ba0da20ed4'
@@ -97,6 +97,7 @@ FunctionsToExport = @(
        'New-EWSMessage'
     
    'Connect-EWSService'
+       'Get-EWSService'
 )
 
 # Cmdlets to export from this module

--- a/EWS/Get-EWSService.ps1
+++ b/EWS/Get-EWSService.ps1
@@ -1,0 +1,12 @@
+﻿function Get-EWSService {
+    [OutputType('Microsoft.Exchange.WebServices.Data.ExchangeService')]
+    [CmdletBinding()]
+    Param(
+        
+    )
+    if ($Script:exchangeService){
+        $Script:exchangeService
+    } else {
+        Write-Information -MessageData "No Active Session Found" -InformationAction Continue
+    }
+}


### PR DESCRIPTION
Roughly analogous to `Get-PSSession`

Useful for checking whether or not a connection needs to be initiated in scripts which use EWS